### PR TITLE
Added the option to toggle the case of the selected text.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,11 @@ export default class TextFormat extends Plugin {
       callback: () => this.textFormat("uppercase"),
     });
     this.addCommand({
+      id: "text-format-toggle",
+      name: "Togglecase selected text",
+      callback: () => this.textFormat("togglecase"),
+    });
+    this.addCommand({
       id: "text-format-capitalize-word",
       name: "Capitalize all words in selected text",
       callback: () => this.textFormat("capitalize-word"),
@@ -197,6 +202,19 @@ export default class TextFormat extends Plugin {
         break;
       case "uppercase":
         replacedText = selectedText.toUpperCase();
+        break;
+      case "togglecase":
+          for (var i = 0; i < selectedText.length; i++) {
+            var char = selectedText.charAt(i);
+            if (char.toUpperCase()!=char.toLowerCase()) {
+              if (char != char.toUpperCase()) {
+                replacedText = selectedText.toUpperCase();
+              } else {
+                replacedText = selectedText.toLowerCase();
+              }
+              break;
+            }
+          }
         break;
       case "capitalize-word":
         replacedText = capitalizeWord(selectedText);


### PR DESCRIPTION
Hi.

Love your plugin but I was a bit frustrated having to map the keyboard shortcuts to uppercase and lower case. So I added the option just to toggle the case. The logic of choosing if the selected text is upper case or lower case is just to find the first character that does has a differing case character then covert the selected text the the opposite case of the character. This could be improved to be modern JavaScript but it gets the job done.