### PR TITLE
anki formatted command added

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import {
   zoteroNote,
   textWrapper,
   replaceLigature,
+  ankiSelection,
 } from "src/format";
 import { removeWikiLink, removeUrlLink, url2WikiLink } from "src/link";
 import {
@@ -60,6 +61,11 @@ export default class TextFormat extends Plugin {
       });
     });
 
+    this.addCommand({
+      id: "text-format-anki-card",
+      name: "Convert selection into Anki card format",
+      callback: () => this.textFormat("anki"),
+    });
     this.addCommand({
       id: "text-format-ligature",
       name: "Replace ligature",
@@ -286,6 +292,9 @@ export default class TextFormat extends Plugin {
 
     // modify selection text
     switch (cmd) {
+      case "anki":
+        replacedText = ankiSelection(selectedText);
+        break;
       case "lowercase":
         replacedText = selectedText.toLowerCase();
         break;

--- a/src/format.ts
+++ b/src/format.ts
@@ -28,6 +28,51 @@ export function capitalizeSentence(s: string): string {
   });
 }
 
+export function ankiSelection(str: string): string {
+  let sections = str.split(/\r?\n/)
+  var seclen = sections.length;
+  let returned = "";
+
+  if (sections[0] == ""){
+      sections.shift();
+      returned += "\n"
+  }
+
+  if (seclen > 1) {
+      returned += "START\nCloze\n";
+      let i = 1;
+      let gap = 0;
+      sections.forEach(function(entry){
+          if (entry != "" && gap > 0) {
+              returned += "\nBack Extra:\nTags:\nEND\n";
+              for (let n = 0; n < gap; n++) {
+                  returned += "\n";
+              } 
+              returned += "START\nCloze\n";
+              gap = 0;
+              i = 1;
+          }
+          
+          if (entry != "") {
+              returned += "{{c" + i + "::" + entry + "}} ";
+              i++;
+          }
+          else {
+              gap++;
+          }
+      });
+      returned += "\nBack Extra:\nTags:\nEND";
+      for (let n = 0; n < gap; n++) {
+          returned += "\n";
+      } 
+      return returned;
+  }
+  else {
+      return str;
+  }
+
+}
+
 export function removeAllSpaces(s: string): string {
   return s.replace(/(?<![\)\]:#-]) | $/g, "");
 }


### PR DESCRIPTION
Added command that can format text into Anki card format (Cloze deletion only) according to the Obsidian_to_Anki plugins default formatting rules.

Simply highlight text and it will turn them into cards, different lines will be treated as different "sides" on the cards.

E.g.
my question
my answer
my third piece

Will become:
START
Cloze
{{c1::my question}} {{c2::my answer}} {{c3::my third piece}} Back Extra:
Tags:
END