### PR TITLE
Add slugify text transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Obsidian Downloads](https://img.shields.io/badge/dynamic/json?color=7e6ad6&labelColor=34208c&label=Obsidian%20Downloads&query=$['obsidian-text-format'].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&)](obsidian://show-plugin?id=obsidian-text-format) ![GitHub stars](https://img.shields.io/github/stars/Benature/obsidian-text-format?style=flat)
 
 Sometimes I encounter some issues like  
-1. I copy some text from pdf or some other source, but the copied content is out of format. For example, there are more than one space between words or one paragraph brokes into several lines.  
+1. I copy some text from pdf or some other source, but the copied content is out of format. For example, there are more than one space between words or one paragraph broke into several lines.  
 2. I want to lowercase the letters when they are all uppercase, etc.
 
 Therefore, I wrote this plugin to format selected text lowercase/uppercase/capitalize/titlecase or remove redundant spaces/newline characters, and other features listed below.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ Or you can consider to bind custom hotkeys to those commands according to [#29](
 
 ### Basic
 
-| Command                                                           | Description                                                                                                                                                                        |
-| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lowercase** selected text                                       | Lowercase all letters in selection                                                                                                                                                 |
-| **Uppercase** selected text                                       | Uppercase all letters in selection                                                                                                                                                 |
+| Command                                                            | Description                                                                                                                                                                        |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lowercase** selected text                                        | Lowercase all letters in selection                                                                                                                                                 |
+| **Uppercase** selected text                                        | Uppercase all letters in selection                                                                                                                                                 |
 | **Capitalize** all **words** in selected text ⚙️                   | Capitalize all words in selection                                                                                                                                                  |
 | **Capitalize** only first word of **sentence** in selected text ⚙️ | Capitalize only first word of sentence(s) in selection                                                                                                                             |
 | **Title case** selected text ⚙️                                    | Capitalize words but leave certain words in lower case in selection *(Note: not support Cyrillic strings for now)* [#1](https://github.com/Benature/obsidian-text-format/issues/1) |
 | **Tooglecase**selected text ⚙️                                     | A custom loop to format the selection                                                                                                                                              |
+|  **Slugify**selected text ⚙️                                     | convert any input text into a URL-friendly slug                                                                                                                                              |
 
 
 ### List
@@ -140,6 +141,11 @@ If you find this plugin useful and would like to support its development, you ca
   - Obsidian is a good app.
   + Obsidian Is a Good App.
                 ^
+  ```
+- slugify
+  ```diff
+  - Obsidian - a good app.
+  + obsidian-a-good-app
   ```
 - redundant spaces
   ```diff

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,8 @@ import {
   replaceLigature,
   ankiSelection,
   sortTodo,
-  requestAPI
+  requestAPI,
+  slugify
 } from "src/format";
 import { removeWikiLink, removeUrlLink, url2WikiLink } from "src/link";
 import {
@@ -211,6 +212,11 @@ export default class TextFormat extends Plugin {
       name: "Sort to-do list",
       callback: () => this.textFormat("todo-sort"),
     });
+    this.addCommand({
+      id: "text-format-slugify",
+      name: "Slugify",
+      callback: () => this.textFormat("slugify"),
+    })
     this.addCommand({
       id: "text-format-api-request",
       name: "Format with API",
@@ -503,6 +509,9 @@ export default class TextFormat extends Plugin {
         break;
       case "todo-sort":
         replacedText = sortTodo(selectedText);
+        break;
+      case "slugify":
+        replacedText = slugify(selectedText);
         break;
       case "api-request":
         let p = requestAPI(selectedText, markdownView.file, this.settings.RequestURL);

--- a/src/format.ts
+++ b/src/format.ts
@@ -404,7 +404,7 @@ export function sortTodo(s: string): string {
                 todo_detected = true;
             } else {
                 if (head.length < indent) {
-                    // the level of this line is higher than before, 
+                    // the level of this line is higher than before,
                     // reset the index and consider above lines as prefix text
                     prefix_text_line = i - 1;
                     indent = head.length;
@@ -491,4 +491,41 @@ export async function requestAPI(s: string, file: TFile, url: string): Promise<s
         new Notice(`Fail to request API.\n${e}`);
         return s;
     }
+}
+
+export function slugify(text: string, maxLength: number = 76): string {
+    // Convert to Lowercase
+    text = text.toLowerCase();
+
+    // Remove Special Characters
+    text = text.replace(/[^\w\s]|_/g, "").replace(/\s+/g, " ").trim();
+
+    // Replace Spaces with Dashes
+    text = text.replace(/\s+/g, "-");
+
+    // Remove Accents and Diacritics
+    text = text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+
+    // Handle Multiple Dashes
+    text = text.replace(/-{2,}/g, "-");
+
+    // Handle Numerals
+    if (/^\d+$/.test(text)) {
+        // If the slug is numeric only, add a suffix to make it unique and descriptive
+        text = `item-${text}`;
+    }
+
+    // Truncate Length if required
+    if (text.length > maxLength) {
+        text = text.substr(0, maxLength);
+        // Handle case where the last character is a hyphen
+        if (text.endsWith("-")) {
+            text = text.substr(0, text.lastIndexOf("-"));
+        }
+    }
+
+    // Handle Hyphens and Dashes
+    text = text.replace(/^-+|-+$/g, "");
+
+    return text;
 }


### PR DESCRIPTION
The PR introduces a new slugify function in the src/format.ts file. The slugify function will convert a string into a URL-friendly format, removing special characters, converting to lowercase, replacing spaces with dashes, removing accents and diacritics, and handling numerals and hyphens. This utility is helpful in generating slugs for URLs or filenames from a given text, making the text more SEO-friendly and easier to manage.
    
The function has also been incorporated into the main.ts file, adding slugify into the list of available commands, and handling the text formatting case, allowing users to apply the slugify function on their selected text.

NOTE: I'm not JavaScript/TypeScript programmer - please check carefully against errors.