### PR TITLE
Add "Snakify" command to convert to lowercase and add underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or you can consider to bind custom hotkeys to those commands according to [#29](
 | **Capitalize** only first word of **sentence** in selected text ⚙️ | Capitalize only first word of sentence(s) in selection                                                                                                                             |
 | **Title case** selected text ⚙️                                    | Capitalize words but leave certain words in lower case in selection *(Note: not support Cyrillic strings for now)* [#1](https://github.com/Benature/obsidian-text-format/issues/1) |
 | **Tooglecase**selected text ⚙️                                     | A custom loop to format the selection                                                                                                                                              |
-
+| **Snakify** selected text ⚙️ | Lowercase all letters in selection *and* replace spaces with underscores |
 
 ### List
 | Command                                  | Description                                                                                                                                           |
@@ -140,6 +140,11 @@ If you find this plugin useful and would like to support its development, you ca
   - Obsidian is a good app.
   + Obsidian Is a Good App.
                 ^
+  ```
+- snakify
+  ```diff
+  - Obsidian is a good app
+  + obsidian_is_a_good_app
   ```
 - redundant spaces
   ```diff

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,8 @@ import {
   replaceLigature,
   ankiSelection,
   sortTodo,
-  requestAPI
+  requestAPI,
+  snakify
 } from "src/format";
 import { removeWikiLink, removeUrlLink, url2WikiLink } from "src/link";
 import {
@@ -216,6 +217,11 @@ export default class TextFormat extends Plugin {
       name: "Format with API",
       callback: () => this.textFormat("api-request"),
     });
+    this.addCommand({
+      id: "text-format-snakify",
+      name: "Snakify",
+      callback: () => this.textFormat("snakify"),
+    })
     this.addCommand({
       id: "text-format-space-word-symbol",
       name: "Format space between word and symbol",
@@ -513,6 +519,9 @@ export default class TextFormat extends Plugin {
         break;
       case "todo-sort":
         replacedText = sortTodo(selectedText);
+        break;
+      case "snakify":
+        replacedText = snakify(selectedText);
         break;
       case "api-request":
         let p = requestAPI(selectedText, markdownView.file, this.settings.RequestURL);

--- a/src/format.ts
+++ b/src/format.ts
@@ -405,7 +405,7 @@ export function sortTodo(s: string): string {
                 todo_detected = true;
             } else {
                 if (head.length < indent) {
-                    // the level of this line is higher than before, 
+                    // the level of this line is higher than before,
                     // reset the index and consider above lines as prefix text
                     prefix_text_line = i - 1;
                     indent = head.length;
@@ -492,4 +492,10 @@ export async function requestAPI(s: string, file: TFile, url: string): Promise<s
         new Notice(`Fail to request API.\n${e}`);
         return s;
     }
+}
+
+export function snakify(text: string, maxLength: number = 76): string {
+    text = text.toLowerCase();
+    text = text.replace(/\s+/g, "_");
+    return text;
 }


### PR DESCRIPTION
I use snake case (`snake_case`) for my file names in Obsidian. I often find myself copying and pasting titles of papers and then manually converting them to lowercase and replacing spaces with underscores. I found this plugin when searching for a way to end the misery. Inspired by the implementation in #57, I added the "Snakify" command for my use case. Sharing in case anyone else is running into the same issue!